### PR TITLE
Improve of AutoName function

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,40 @@ A client side mapart utility mod designed for 2b2t mapart enthusiasts!
 # About
 This mod was made because I am too lazy to manually copy 2000+ (probably a lot more since writing this) unique maps more than once. Some of the features include: map copier, auto locker, map downloader, and a duplicate checker.
 
+# Crow patches
+
+<b> I make some patches, especially for 2b2t. 
+They may be broken in the singleplayer or work on the other servers not as good as on 2b2t</b> <br>
+
+[`discord`|`telegram`] --> @CrowTheBest
+
+### AutoName maparts
+<b> Important note: SMI AutoNamer hasn't been changed </b> <br>
+
+example: `/nameMap 25 35 0 [{x}, {y}] The True Kings`
+- Now `{x}` and `{y}` require in the name. It gives you a possibility to change their positions in the name!
+- Fixed mismatch the sequence of names (x/y) (when anvil breaks, and then it tries to rename each map again)
+- Added different sounds after renaming is done or an anvil has broken
+- Removed annoying anvil sound while renaming
+- fixed a case when an anvil breaks and the renamed map is not put in its place
+- Added custom delay between actions <br> 
+It applies to each action, either rename or slot actions BUT NOT FOR TAKING AND PUTTING MAPS IN SHULKER. Be careful on the servers! <br>
+It could be added in the future, maybe even global delay as a separate command
+
+It's quite easy in use! If you want to continue renaming process somewhere in the middle of your mapart, 
+take the previous renamed maps and open an anvil. You will be notified in chat previous indexes have been updated.
+Put the maps back and take next maps, they will be renamed according to the sequence! <br>
+<b><u> Make sure you have changed the name with </u>`/nameMap`<u> command, and it matches what you've named previous maps, before open an anvil </b></u>
+
+### Taking maps from a shulker
+- Now it doesn't take any other item but maps!
+
+## TODO
+Here listed things I'm thinking on and/or want to implement
+
+- Auto copy fix, when it takes <27 empty maps and it gets stuck after renaming
+- Always take and put in a shulker a full stack of maps, if AutoNamer enabled
+
 # What is SMI?
 SMI (Stalpo Mapart Index) is a system used to try and archive all maparts on 2b2t by giving them each a unique id. Sadly I suck at coding and planning so this collection will have to be manually updated. If you have any maparts that aren't indexed yet please contact me! For now no obviously nsfw maps will be included just because I'm hosting on Google Drive.
 
@@ -21,7 +55,7 @@ Download the collection, extract the maparts_smi folder, and paste the folder in
 7. SMI Namer
 
 # Commands
-1. /nameMap x y name 
+1. /nameMap x y delay name_{x}_{y} 
 
 used for the map namer
 

--- a/README.md
+++ b/README.md
@@ -4,40 +4,6 @@ A client side mapart utility mod designed for 2b2t mapart enthusiasts!
 # About
 This mod was made because I am too lazy to manually copy 2000+ (probably a lot more since writing this) unique maps more than once. Some of the features include: map copier, auto locker, map downloader, and a duplicate checker.
 
-# Crow patches
-
-<b> I make some patches, especially for 2b2t. 
-They may be broken in the singleplayer or work on the other servers not as good as on 2b2t</b> <br>
-
-[`discord`|`telegram`] --> @CrowTheBest
-
-### AutoName maparts
-<b> Important note: SMI AutoNamer hasn't been changed </b> <br>
-
-example: `/nameMap 25 35 0 [{x}, {y}] The True Kings`
-- Now `{x}` and `{y}` require in the name. It gives you a possibility to change their positions in the name!
-- Fixed mismatch the sequence of names (x/y) (when anvil breaks, and then it tries to rename each map again)
-- Added different sounds after renaming is done or an anvil has broken
-- Removed annoying anvil sound while renaming
-- fixed a case when an anvil breaks and the renamed map is not put in its place
-- Added custom delay between actions <br> 
-It applies to each action, either rename or slot actions BUT NOT FOR TAKING AND PUTTING MAPS IN SHULKER. Be careful on the servers! <br>
-It could be added in the future, maybe even global delay as a separate command
-
-It's quite easy in use! If you want to continue renaming process somewhere in the middle of your mapart, 
-take the previous renamed maps and open an anvil. You will be notified in chat previous indexes have been updated.
-Put the maps back and take next maps, they will be renamed according to the sequence! <br>
-<b><u> Make sure you have changed the name with </u>`/nameMap`<u> command, and it matches what you've named previous maps, before open an anvil </b></u>
-
-### Taking maps from a shulker
-- Now it doesn't take any other item but maps!
-
-## TODO
-Here listed things I'm thinking on and/or want to implement
-
-- Auto copy fix, when it takes <27 empty maps and it gets stuck after renaming
-- Always take and put in a shulker a full stack of maps, if AutoNamer enabled
-
 # What is SMI?
 SMI (Stalpo Mapart Index) is a system used to try and archive all maparts on 2b2t by giving them each a unique id. Sadly I suck at coding and planning so this collection will have to be manually updated. If you have any maparts that aren't indexed yet please contact me! For now no obviously nsfw maps will be included just because I'm hosting on Google Drive.
 
@@ -55,7 +21,7 @@ Download the collection, extract the maparts_smi folder, and paste the folder in
 7. SMI Namer
 
 # Commands
-1. /nameMap x y delay name_{x}_{y} 
+1. /nameMap x y name 
 
 used for the map namer
 

--- a/src/main/java/net/stalpo/stalpomaparthelper/MapartShulker.java
+++ b/src/main/java/net/stalpo/stalpomaparthelper/MapartShulker.java
@@ -512,23 +512,19 @@ public class MapartShulker {
             // this loop ensures the server ACTUALLY processed renaming
             do {
                 if (anvilBroken) { return; }
-//                sh.onContentChanged(inventory);
 
+//                these lines fix singleplayer renaming
+//                sh.onContentChanged(inventory);
 //                mc.player.networkHandler.sendPacket(new RenameItemC2SPacket(newName));
+
                 ((AnvilScreen)MinecraftClient.getInstance().currentScreen).onRenamed(newName);
                 try { TimeUnit.MILLISECONDS.sleep(delay); } catch (InterruptedException ignored) { }
 
                 sh.onContentChanged(inventory);
-//                inventory.updateItems();  // do NOT delete this, otherwise it lead to false slot actions
 
             } while (!Objects.equals(mc.player.currentScreenHandler.getSlot(2).getStack().getName().getString(), newName));
 
             moveStack(2, i + 3);
-
-            // do NOT delete this, otherwise it lead to false slot actions. Yes, two times
-            // it fixes 1/500 case of anvil desync on the next rename with low delay
-//            sh.onContentChanged(inventory);
-//            inventory.updateItems();
             currentExpLevel--;
         }
 

--- a/src/main/java/net/stalpo/stalpomaparthelper/MapartShulker.java
+++ b/src/main/java/net/stalpo/stalpomaparthelper/MapartShulker.java
@@ -1,31 +1,41 @@
 package net.stalpo.stalpomaparthelper;
 
+import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.gui.screen.ingame.AnvilScreen;
+import net.minecraft.client.render.MapRenderer;
 import net.minecraft.client.render.RenderLayer;
 import net.minecraft.client.render.VertexConsumer;
 import net.minecraft.client.render.VertexConsumerProvider;
+import net.minecraft.client.sound.PositionedSoundInstance;
 import net.minecraft.client.util.math.MatrixStack;
 import net.minecraft.component.DataComponentTypes;
 import net.minecraft.component.type.MapIdComponent;
+import net.minecraft.entity.player.PlayerInventory;
 import net.minecraft.item.EmptyMapItem;
 import net.minecraft.item.Items;
-import net.stalpo.stalpomaparthelper.interfaces.InventoryExporter;
+import net.minecraft.item.FilledMapItem;
+import net.minecraft.item.map.MapState;
+import net.minecraft.screen.AnvilScreenHandler;
+import net.minecraft.sound.SoundEvent;
+import net.minecraft.sound.SoundEvents;
 import net.stalpo.stalpomaparthelper.interfaces.FakeMapRenderer;
+import net.stalpo.stalpomaparthelper.interfaces.InventoryExporter;
 import net.stalpo.stalpomaparthelper.interfaces.SlotClicker;
 import net.stalpo.stalpomaparthelper.mixin.MapRendererInvoker;
 import net.stalpo.stalpomaparthelper.mixin.MapTextureAccessor;
+import net.minecraft.screen.ScreenHandler;
 import net.minecraft.screen.slot.SlotActionType;
 import net.minecraft.inventory.Inventory;
-import net.minecraft.screen.ScreenHandler;
-import net.minecraft.item.FilledMapItem;
-import net.minecraft.client.MinecraftClient;
-import net.minecraft.item.map.MapState;
-import net.minecraft.client.render.MapRenderer;
 
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.concurrent.TimeUnit;
+import java.util.HashMap;
 
 public class MapartShulker {
     public static ScreenHandler sh;
@@ -37,11 +47,19 @@ public class MapartShulker {
 
     private static List<MapState> states;
 
-    public static String mapName = "StalpoIsAwesome";
+    public static String mapName = "StalpoIsAwesome! ({x} {y})";
     public static int mapX = 1;
     public static int mapY = 1;
     public static int currX = 0;
     public static int currY = 0;
+    public static int delay = 5;
+    public static int lastMapId = -1;
+    public static boolean anvilBroken = false;
+
+    public static SoundEvent AnvilBrokenSound = SoundEvents.ENTITY_VILLAGER_NO;
+    public static SoundEvent RenameFinishedSound = SoundEvents.BLOCK_AMETHYST_BLOCK_STEP;
+    public static Pattern namePattern = null;
+    public static HashMap<Integer, Integer> mapsSequence;
 
     public static List<MapIdComponent> getIds(){
         Inventory inventory = ((InventoryExporter)sh).getInventory();
@@ -255,6 +273,9 @@ public class MapartShulker {
         StalpoMapartHelper.LOGCHAT("Taking shulker");
         Inventory inventory = ((InventoryExporter)sh).getInventory();
         for(int i = 0; i < inventory.size(); i++){
+            if (MinecraftClient.getInstance().player.currentScreenHandler.getSlot(i).getStack().getItem().getClass() != FilledMapItem.class) {
+                continue;
+            }
             moveOne(i, i+27);
         }
     }
@@ -324,38 +345,204 @@ public class MapartShulker {
         StalpoMapartHelper.LOGCHAT("Finished locking maps");
     }
 
-    public static void nameMaps(){
-        StalpoMapartHelper.LOGCHAT("Naming shulk");
-        Inventory inventory = MinecraftClient.getInstance().player.getInventory();
-        for(int i = 0; i < 27; i++){
-            if(inventory.getStack(i+9).getItem().getClass() != FilledMapItem.class){
-                continue;
+    public static int findByMapId(PlayerInventory inventory, int mapId) {
+        int timer = 0;
+        do {
+            for (int slot = 0; slot < 45; slot++) {
+                if (inventory.getStack(slot).getItem().getClass() != FilledMapItem.class) {
+                    StalpoMapartHelper.LOG("[debug] slot: " + slot + "; item: " + inventory.getStack(slot).getItem().getName().getString());
+                    continue;
+                }
+                StalpoMapartHelper.LOG("[debug] slot: " + slot + "; map id: " + inventory.getStack(slot).get(DataComponentTypes.MAP_ID).id()
+                        + " required: " + mapId + "; result: " + (inventory.getStack(slot).get(DataComponentTypes.MAP_ID).id() == mapId));
+                if (inventory.getStack(slot).get(DataComponentTypes.MAP_ID).id() == mapId) {
+                    return slot;
+                }
             }
-            if(MinecraftClient.getInstance().player.experienceLevel == 0){
-                StalpoMapartHelper.LOGCHAT("Ran out of xp! turning off auto namer...");
-                StalpoMapartHelper.mapNamerToggled = false;
-                return;
-            }
-            moveOne(i+3, 0);
+            timer++;
 
-            ((AnvilScreen)MinecraftClient.getInstance().currentScreen).onRenamed(mapName + " (" + currX + ", " + currY + ")");
-            currX++;
-            if(currX == mapX){
-                currX = 0;
-                currY ++;
-                if(currY == mapY){
-                    currY = 0;
-                    swap(2, i+3);
-                    StalpoMapartHelper.LOGCHAT("Finished naming map! :D");
-                    StalpoMapartHelper.mapNamerToggled = false;
-                    StalpoMapartHelper.LOGCHAT("Map namer disabled!");
-                    return;
+            try { TimeUnit.MILLISECONDS.sleep(50); } catch (InterruptedException ignored) { }
+            StalpoMapartHelper.LOG("Tryng to find a map. Times: " + timer);
+
+            // INVENTORY CAN BE DESYNCED OR NOT UPDATED YET WE ARE WAITING FOR SYNCHRONIZE DON'T ASK ME PLEASE IT WORKS AFTER ALL
+        }  while (timer < 150);
+
+        return -1;
+    }
+
+    public static void sortInventoryAfterRename() {
+        // This function checks for the right map sequence after an anvil breaks. Please don't use it somewhere else.
+        // Things we know for now (no need to check them):
+        // 1. An anvil has broken, so our gui is closed
+        // 2. We DO have maps provided in "MapartShulker.mapsSequence" in the inventory
+
+        StalpoMapartHelper.LOG("sorting inventory");
+        do { try { TimeUnit.MILLISECONDS.sleep(5); } catch (InterruptedException ignored) { }
+        } while (MinecraftClient.getInstance().player.currentScreenHandler instanceof AnvilScreenHandler);
+
+        MinecraftClient mc = MinecraftClient.getInstance();
+        mc.player.currentScreenHandler = MinecraftClient.getInstance().player.playerScreenHandler;
+        sh = MinecraftClient.getInstance().player.currentScreenHandler;
+        int syncId = MinecraftClient.getInstance().player.playerScreenHandler.syncId;
+
+        // after renaming, a map can be inside crafting slots
+        // i spent 3 days to implement inventory sorting according to the sequence of names...
+        // and deleted it whole... :c
+        // now i check maps if they aren't in their slot. This approach can easily deal with desyncs
+        for (int slot = 0; slot < 45; slot++) {
+            if (sh.getSlot(slot).getStack().getItem().getClass() != FilledMapItem.class) { continue; }
+
+            int currentMapId = sh.getSlot(slot).getStack().get(DataComponentTypes.MAP_ID).id();
+            if (!mapsSequence.containsKey(currentMapId)) { continue; }
+
+            if (slot != mapsSequence.get(currentMapId)) {
+                // idk how to use Stalpo's click here :)
+                mc.interactionManager.clickSlot(syncId, slot, 0, SlotActionType.PICKUP, mc.player);
+                // i don't think we really need delay between clicks... But nonetheless
+                try { TimeUnit.MILLISECONDS.sleep(delay); } catch (InterruptedException ignored) { }
+                mc.interactionManager.clickSlot(syncId, mapsSequence.get(currentMapId), 0, SlotActionType.PICKUP, mc.player);
+                try { TimeUnit.MILLISECONDS.sleep(delay); } catch (InterruptedException ignored) { }
+
+                // THEN we synchronize previous and next slots
+                if (slot - 1 > 8) {
+                    mc.interactionManager.clickSlot(syncId, slot - 1, 0, SlotActionType.PICKUP, mc.player);
+                    try { TimeUnit.MILLISECONDS.sleep(delay); } catch (InterruptedException ignored) { }
+                    mc.interactionManager.clickSlot(syncId, slot - 1, 0, SlotActionType.PICKUP, mc.player);
+                    try { TimeUnit.MILLISECONDS.sleep(delay); } catch (InterruptedException ignored) { }
+                }
+                if (slot + 1 < 45) {
+                    mc.interactionManager.clickSlot(syncId, slot + 1, 0, SlotActionType.PICKUP, mc.player);
+                    try { TimeUnit.MILLISECONDS.sleep(delay); } catch (InterruptedException ignored) { }
+                    mc.interactionManager.clickSlot(syncId, slot + 1, 0, SlotActionType.PICKUP, mc.player);
+                    try { TimeUnit.MILLISECONDS.sleep(delay); } catch (InterruptedException ignored) { }
+                }
+            }
+        }
+    }
+
+    public static void nameMaps() {
+        anvilBroken = false;
+        lastMapId = -1;
+        mapsSequence = new HashMap<>();
+
+        String regex = Pattern.quote(mapName)
+                .replace("{x}", "\\E(?<x>\\d+)\\Q")
+                .replace("{y}", "\\E(?<y>\\d+)\\Q");
+        namePattern = Pattern.compile("^" + regex + "$", Pattern.UNICODE_CASE);
+
+        MinecraftClient mc = MinecraftClient.getInstance();
+        PlayerInventory inventory = mc.player.getInventory();
+        int currentExpLevel = mc.player.experienceLevel;
+
+        StalpoMapartHelper.LOGCHAT("Naming shulk");
+
+        boolean IsFirstMap = true;  // we don't know where the first map is
+        boolean NeedToCheckOffsets = true;  // it becomes false if the first map in inventory has other name than ours OR if the name doesn't match the sequence
+
+        // searching for last map in inventory. Check AnvilSoundSuppressMixin
+        for (int i = 27; i > 0; i--) {
+            if (inventory.getStack(i + 9).getItem().getClass() == FilledMapItem.class) {
+                lastMapId = inventory.getStack(i + 9).get(DataComponentTypes.MAP_ID).id();
+                break;
+            }
+        }
+
+        for (int i = 0; i < 27; i++) {
+            if (anvilBroken) { return; }
+            if (inventory.getStack(i + 9).getItem().getClass() != FilledMapItem.class) { continue; }
+
+            mapsSequence.put(inventory.getStack(i + 9).get(DataComponentTypes.MAP_ID).id(), i + 9);
+
+            // set current X and Y
+            if (!(IsFirstMap) || !(currY == 0 && currX == 0)) {
+                currX++;
+                if (currX == mapX) {
+                    currX = 0;
+                    currY++;
                 }
             }
 
-            swap(2, i+3);
+            // skip already renamed maps
+            Matcher checkName = namePattern.matcher(inventory.getStack(i + 9).getName().getString());
+            if (NeedToCheckOffsets && checkName.matches()) {  // trying to find the latest renamed map
+                int MatchedX = Integer.parseInt(checkName.group("x"));
+                int MatchedY = Integer.parseInt(checkName.group("y"));
+
+                // correct current x and y in case an anvil has broken
+                if (IsFirstMap) {
+                    currX = MatchedX;
+                    currY = MatchedY;
+                    IsFirstMap = false;
+                    continue;
+                }
+                // skip if current map matches the sequence
+                else if (currX == MatchedX && currY == MatchedY) {
+                    continue;
+                }
+            }
+
+            // we found a map without our name! Yaaaaay!
+            // (btw it can be a map with our name, but classified as "not matched" (or not renamed) )
+            if (NeedToCheckOffsets) {
+                StalpoMapartHelper.LOGCHAT("Previous indexes were updated.\nx: " + currX + ",  y: " + currY);
+                NeedToCheckOffsets = false;
+            }
+
+            IsFirstMap = false;
+
+            // I decided to calculate player exp level locally because server sometimes tells the player has 1 exp, but they haven't
+            if (currentExpLevel == 0) {
+                StalpoMapartHelper.LOGCHAT("§6Ran out of xp!");
+                MinecraftClient.getInstance().getSoundManager().play(PositionedSoundInstance.master(MapartShulker.AnvilBrokenSound, 1.0F));
+//                StalpoMapartHelper.mapNamerToggled = false;  // WHY DO YOU DISABLE AUTO NAMER
+                // Imagine if you want to do it the cheapest way possible with EBottles
+                // and it disables itself each time AAAAAAAAAAA
+                return;
+            }
+
+            String newName = mapName.replace("{x}", Integer.toString(currX)).replace("{y}", Integer.toString(currY));
+            // skip already renamed maps
+            if (newName.equals(inventory.getStack(i + 9).getName().getString())) { continue; }
+
+            // I HATE WHEN THE MAP DOESN'T RENAME I HATE HATE HATE HATE HATE HATE HATE HATE HATE HATE HATE HATE HATE HATE HATE HATE HATE HATE HATE HATE HATE HATE
+            // 1 HATE = 1 hour spent on this
+            if (anvilBroken) { return; }
+            moveStack(i + 3, 0);
+
+            // this loop ensures the server ACTUALLY processed renaming
+            do {
+                if (anvilBroken) { return; }
+//                sh.onContentChanged(inventory);
+
+//                mc.player.networkHandler.sendPacket(new RenameItemC2SPacket(newName));
+                ((AnvilScreen)MinecraftClient.getInstance().currentScreen).onRenamed(newName);
+                try { TimeUnit.MILLISECONDS.sleep(delay); } catch (InterruptedException ignored) { }
+
+                sh.onContentChanged(inventory);
+//                inventory.updateItems();  // do NOT delete this, otherwise it lead to false slot actions
+
+            } while (!Objects.equals(mc.player.currentScreenHandler.getSlot(2).getStack().getName().getString(), newName));
+
+            moveStack(2, i + 3);
+
+            // do NOT delete this, otherwise it lead to false slot actions. Yes, two times
+            // it fixes 1/500 case of anvil desync on the next rename with low delay
+//            sh.onContentChanged(inventory);
+//            inventory.updateItems();
+            currentExpLevel--;
         }
-        StalpoMapartHelper.LOGCHAT("Finished naming shulk");
+
+        // here in 99% cases each map has been renamed and the anvil hasn't broken
+        // so, we wait some time
+        try { TimeUnit.MILLISECONDS.sleep(150); } catch (InterruptedException ignored) { }
+        if (anvilBroken) { return; }
+
+        // I want to play another sound if ALL maps have been renamed
+        // we can face a broken anvil on the last renamed map, so we are waiting for anvil gui to close
+        // if it closed, then check AnvilGuiClosedMixin
+        // if it didn't close, then anvil didn't break, so we can play a sound
+        mc.getSoundManager().play(PositionedSoundInstance.master(RenameFinishedSound, 1.0F, 2.0F));
+        StalpoMapartHelper.LOGCHAT("§2Finished naming shulk!");
     }
 
     public static void nameSMIMaps(){
@@ -420,6 +607,20 @@ public class MapartShulker {
         ((SlotClicker)MinecraftClient.getInstance().currentScreen).StalpoMapartHelper$onMouseClick(null, from, 0, SlotActionType.PICKUP);
         ((SlotClicker)MinecraftClient.getInstance().currentScreen).StalpoMapartHelper$onMouseClick(null, to, 0, SlotActionType.PICKUP);
         ((SlotClicker)MinecraftClient.getInstance().currentScreen).StalpoMapartHelper$onMouseClick(null, from, 0, SlotActionType.PICKUP);
+    }
+
+    private static void moveStack(int from, int to){
+        // I use this function in renaming instead of "swap" in case of possible desyncs
+        // added custom delays to use on different servers (default 5 ms)
+        if (MinecraftClient.getInstance().currentScreen != null) {
+            ((SlotClicker)MinecraftClient.getInstance().currentScreen).StalpoMapartHelper$onMouseClick(null, from, 0, SlotActionType.PICKUP);
+            try { TimeUnit.MILLISECONDS.sleep(delay); } catch (InterruptedException ignored) { }
+        }
+
+        if (MinecraftClient.getInstance().currentScreen != null ) {
+            ((SlotClicker)MinecraftClient.getInstance().currentScreen).StalpoMapartHelper$onMouseClick(null, to, 0, SlotActionType.PICKUP);
+            try { TimeUnit.MILLISECONDS.sleep(delay); } catch (InterruptedException ignored) { }
+        }
     }
 
     public static void setNextMap(){

--- a/src/main/java/net/stalpo/stalpomaparthelper/NameMapCommand.java
+++ b/src/main/java/net/stalpo/stalpomaparthelper/NameMapCommand.java
@@ -17,12 +17,21 @@ public final class NameMapCommand {
         dispatcher.register(literal("nameMap")
                 .then(argument("x", integer())
                         .then(argument("y", integer())
-                                .then(argument("name", greedyString())
-                                        .executes(ctx -> NameMap(getString(ctx, "name"), getInteger(ctx, "x"), getInteger(ctx, "y")))))));
+                                .then(argument("delay", integer())
+                                        .then(argument("name", greedyString())
+                                                .executes(ctx -> NameMap(getString(ctx, "name"), getInteger(ctx, "x"), getInteger(ctx, "y"),
+                                                        getInteger(ctx, "delay")
+                                                )))))));
     }
 
-    public static int NameMap(String name, int x, int y) {
+    public static int NameMap(String name, int x, int y, int delay) {
+        if (!name.contains("{x}") || !name.contains("{y}")) {
+            StalpoMapartHelper.CHAT("You have to specify both §4{x}§r and §4{y}§r in the name!\nIf you're using \"§2{§r\" or \"§2}§r\" in the name, just use them as is: §2{§4{x}§r, §4{y}§4}§r");
+            return Command.SINGLE_SUCCESS;  // wha is it
+        }
+
         MapartShulker.mapName = name;
+        MapartShulker.delay = delay;
         MapartShulker.mapX = x;
         MapartShulker.mapY = y;
         MapartShulker.currX = 0;

--- a/src/main/java/net/stalpo/stalpomaparthelper/mixin/AnvilSoundSuppressMixin.java
+++ b/src/main/java/net/stalpo/stalpomaparthelper/mixin/AnvilSoundSuppressMixin.java
@@ -1,0 +1,78 @@
+package net.stalpo.stalpomaparthelper.mixin;
+
+import net.minecraft.client.MinecraftClient;
+import net.minecraft.client.gui.screen.ingame.AnvilScreen;
+import net.minecraft.client.sound.AbstractSoundInstance;
+import net.minecraft.client.sound.PositionedSoundInstance;
+import net.minecraft.util.Identifier;
+import net.minecraft.util.Util;
+import net.stalpo.stalpomaparthelper.MapartShulker;
+import net.stalpo.stalpomaparthelper.StalpoMapartHelper;
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+import java.util.regex.Matcher;
+
+@Mixin(AbstractSoundInstance.class)
+public class AnvilSoundSuppressMixin {
+    @Final
+    @Shadow
+    protected Identifier id;
+
+    @Inject(method = "getVolume()F", at = @At("HEAD"), cancellable = true)
+    private void getVolume(CallbackInfoReturnable<Float> callback) {
+        // remove annoying anvil use sound
+        if (StalpoMapartHelper.mapNamerToggled & MinecraftClient.getInstance().currentScreen instanceof AnvilScreen) {
+            if (id.toString().equals("minecraft:block.anvil.use")) {
+                callback.setReturnValue(0.0F);
+                callback.cancel();
+            }
+
+            // if the anvil has broken, then check the sequence of names, search for map and put the map back to its slot
+            else if (id.toString().equals("minecraft:block.anvil.destroy")) {
+                MapartShulker.anvilBroken = true;
+                callback.setReturnValue(0.0F);
+                callback.cancel();
+
+                Util.getIoWorkerExecutor().execute(this::executeAfterAnvilBreak);
+            }
+        }
+    }
+
+    @Unique
+    private void executeAfterAnvilBreak() {
+        Util.getIoWorkerExecutor().execute(MapartShulker::sortInventoryAfterRename);
+
+        // if THE LAST map has been renamed, then play MapartShulker.RenameFinishedSound
+
+        if (MapartShulker.lastMapId == -1) {
+            MinecraftClient.getInstance().getSoundManager().play(PositionedSoundInstance.master(MapartShulker.AnvilBrokenSound, 1.0F));
+            StalpoMapartHelper.LOGCHAT("§6Anvil has broken!");
+            return;
+        }
+
+        int lastMapSlot = MapartShulker.findByMapId(MinecraftClient.getInstance().player.getInventory(), MapartShulker.lastMapId);
+        // how is it possible?? Well, I just left it here!
+        if (lastMapSlot == -1) {
+            MinecraftClient.getInstance().getSoundManager().play(PositionedSoundInstance.master(MapartShulker.AnvilBrokenSound, 1.0F));
+            StalpoMapartHelper.LOGCHAT("§6Anvil has broken!");
+            return;
+        }
+
+        Matcher checkName = MapartShulker.namePattern.matcher(MinecraftClient.getInstance().player.getInventory().getStack(lastMapSlot).getName().getString());
+
+        if (checkName.matches()) {
+            MinecraftClient.getInstance().getSoundManager().play(PositionedSoundInstance.master(MapartShulker.RenameFinishedSound, 1.0F, 2.0F));
+            return;
+        }
+
+        MinecraftClient.getInstance().getSoundManager().play(PositionedSoundInstance.master(MapartShulker.AnvilBrokenSound, 1.0F));
+        StalpoMapartHelper.LOGCHAT("§6Anvil has broken!");
+    }
+
+}

--- a/src/main/resources/stalpomaparthelper.mixins.json
+++ b/src/main/resources/stalpomaparthelper.mixins.json
@@ -1,15 +1,18 @@
 {
-	"required": true,
-	"package": "net.stalpo.stalpomaparthelper.mixin",
-	"compatibilityLevel": "JAVA_17",
-	"mixins": [
-		"GuiContainerMixin",
-		"HandledScreenMixin",
-		"ShulkerBoxScreenHandlerMixin",
-		"MapRendererInvoker",
-		"MapTextureAccessor"
-	],
-	"injectors": {
-		"defaultRequire": 1
-	}
+  "required": true,
+  "package": "net.stalpo.stalpomaparthelper.mixin",
+  "compatibilityLevel": "JAVA_17",
+  "mixins": [
+    "GuiContainerMixin",
+    "HandledScreenMixin",
+    "MapRendererInvoker",
+    "MapTextureAccessor",
+    "ShulkerBoxScreenHandlerMixin"
+  ],
+  "injectors": {
+    "defaultRequire": 1
+  },
+  "client": [
+    "AnvilSoundSuppressMixin"
+  ]
 }


### PR DESCRIPTION
The main change is that the script now follows the sequence of map names and checks it if the anvil was broken 

Other changes just make the process better and easier!

- Fixed mismatch the sequence of names (x/y) (when anvil breaks, and then it tries to rename each map again)
- Now {x} and {y} require in the name. It gives you a possibility to change their positions in the name!
- Added different sounds after renaming is done or an anvil has broken
- Removed annoying anvil sound while renaming
- Fixed a case when an anvil breaks and the renamed map is not put in its place
- Added custom delay between actions

I tested changes on 2b2t. It works fine with cheat clients and on Zenith Proxy with 0 delay! 
In the singleplayer there may be some desyncs with low delay. It is odd, just use delay > 30 ms. (I think nobody will use this function in singleplayer 👍)