### PR TITLE
2b Compatibility Fix 

### DIFF
--- a/src/main/java/net/stalpo/stalpomaparthelper/MapartShulker.java
+++ b/src/main/java/net/stalpo/stalpomaparthelper/MapartShulker.java
@@ -590,8 +590,11 @@ public class MapartShulker {
 
     private static void moveOne(int from, int to){
         ((SlotClicker)MinecraftClient.getInstance().currentScreen).StalpoMapartHelper$onMouseClick(null, from, 0, SlotActionType.PICKUP);
+        try { TimeUnit.MILLISECONDS.sleep(delay); } catch (InterruptedException ignored) { }
         ((SlotClicker)MinecraftClient.getInstance().currentScreen).StalpoMapartHelper$onMouseClick(null, to, 1, SlotActionType.PICKUP);
+        try { TimeUnit.MILLISECONDS.sleep(delay); } catch (InterruptedException ignored) { }
         ((SlotClicker)MinecraftClient.getInstance().currentScreen).StalpoMapartHelper$onMouseClick(null, from, 0, SlotActionType.PICKUP);
+        try { TimeUnit.MILLISECONDS.sleep(delay); } catch (InterruptedException ignored) { }
     }
 
     private static void moveHalf(int from, int to){


### PR DESCRIPTION
Added multiple delays on the moveOne function after every movement to circumvent the new plugins that have to do with chest and inventory shit 

the delays don't change the speed of the mod, works at about the same speed as before the new plugins/delays 

NOTE* 

BUG
there is a glitch that I found on 2b if you only have one stack of empty maps in the hot bar the mod will terminate prematurely for some reason. I don't know how to fix it properly in the code, but I couldn't find the exact cause. 

FIX
The fix is to make sure you have two stacks of maps in your hot bar at all times when using the copier. For example, if you have one stack of empty maps make sure to split it 32, 32 to prevent premature termination. 

Also make sure to add that point into the read.me file just so everyone knows 